### PR TITLE
Add reference to Xamarin.Android.Volley

### DIFF
--- a/samples/NotificationHubSample.Android/NotificationHubSample.Android.csproj
+++ b/samples/NotificationHubSample.Android/NotificationHubSample.Android.csproj
@@ -53,6 +53,9 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xamarin.Android.Volley">
+      <Version>1.1.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.GooglePlayServices.Base">


### PR DESCRIPTION
This library is critical for use with azure-notificationhubs-android starting at version 1.0.0.

Fixes an issue where customers trying to run this sample will encounter the following message:
```
Java.Lang.NoClassDefFoundError: Failed resolution of: Lcom/android/volley/DefaultRetryPolicy; ---> Java.Lang.ClassNotFoundException: Didn't find class "com.android.volley.DefaultRetryPolicy
```