### PR TITLE
Initializes Android Application with custom Installation Adapter

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs.Client/NotificationHub.android.cs
+++ b/src/Microsoft.Azure.NotificationHubs.Client/NotificationHub.android.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.NotificationHubs.Client
             AndroidNotificationHub.SetListener(_listener);
             AndroidNotificationHub.SetInstallationSavedListener(_installationSavedListener);
             AndroidNotificationHub.SetInstallationSaveFailureListener(_installationErrorListener);
+            AndroidNotificationHub.Start((Application)Application.Context, _installationAdapter);
         }
 
         static void PlatformSetEnricher() => AndroidNotificationHub.UseVisitor(_installationEnrichmentVisitor);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes to call `NotificationHub.Start` method for a custom installation adapter.

## Related PRs or issues

#24 

## Misc
