### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/src/bindings/cgmanifest.json
+++ b/src/bindings/cgmanifest.json
@@ -1,26 +1,27 @@
 {
-    "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/Azure/azure-notificationhubs-ios.git", 
-         "commitHash": "e4cf0b765f88448ee0d1298a34f1ef73764ee54e" 
-         },
-        "nugetId" : "Xamarin.Azure.NotificationHubs.iOS"
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/Azure/azure-notificationhubs-ios.git",
+          "commitHash": "e4cf0b765f88448ee0d1298a34f1ef73764ee54e"
+        },
+        "nugetId": "Xamarin.Azure.NotificationHubs.iOS"
+      }
     },
     {
       "Component": {
-         "Type": "Maven",
-         "Maven": {
-           "ArtifactId": "notification-hubs-android-sdk",
-           "GroupId": "com.microsoft.azure",
-           "Version": "1.0.0-preview2"
-         },
-         "nugetId" : "Xamarin.Azure.NotificationHubs.Android"
-       }
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "notification-hubs-android-sdk",
+          "GroupId": "com.microsoft.azure",
+          "Version": "1.0.0-preview2"
+        },
+        "nugetId": "Xamarin.Azure.NotificationHubs.Android"
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.